### PR TITLE
Fixing explorer block links

### DIFF
--- a/coins/testnet/zec.json
+++ b/coins/testnet/zec.json
@@ -25,7 +25,7 @@
 
     "explorer": {
         "txURL": "https://explorer.testnet.z.cash/tx/",
-        "blockURL": "https://explorer.testnet.z.cash/blocks/",
+        "blockURL": "https://explorer.testnet.z.cash/block/",
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://explorer.coin.com/tx/). The pool will automatically add the transaction id or block id at the end."
     }
 }

--- a/coins/testnet/zen.json
+++ b/coins/testnet/zen.json
@@ -31,7 +31,7 @@
 
     "explorer": {
         "txURL": "https://explorer-testnet.zen-solutions.io/tx/",
-        "blockURL": "https://explorer-testnet.zen-solutions.io/blocks/",
+        "blockURL": "https://explorer-testnet.zen-solutions.io/block/",
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://explorer.coin.com/tx/). The pool will automatically add the transaction id or block id at the end."
     }
 }

--- a/coins/vot.json
+++ b/coins/vot.json
@@ -9,7 +9,7 @@
 
     "explorer": {
         "txURL": "https://explorer.votecoin.site/tx/",
-        "blockURL": "https://explorer.votecoin.site/blocks/",
+        "blockURL": "https://explorer.votecoin.site/block/",
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://explorer.coin.com/tx/). The pool will automatically add the transaction id or block id at the end."
     }
 }

--- a/coins/xsg.json
+++ b/coins/xsg.json
@@ -38,7 +38,7 @@
 
     "explorer": {
         "txURL": "https://insight.snowgem.org/tx/",
-        "blockURL": "https://insight.snowgem.org/blocks/",
+        "blockURL": "https://insight.snowgem.org/block/",
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://explorer.coin.com/tx/). The pool will automatically add the transaction id or block id at the end."
     }
 }

--- a/coins/zec.json
+++ b/coins/zec.json
@@ -62,7 +62,7 @@
 
     "explorer": {
         "txURL": "https://explorer.z.cash/tx/",
-        "blockURL": "https://explorer.z.cash/blocks/",
+        "blockURL": "https://explorer.z.cash/block/",
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://explorer.coin.com/tx/). The pool will automatically add the transaction id or block id at the end."
     }
 }


### PR DESCRIPTION
Links to insight explorers need to be `/block/`, not `/blocks`. The
`/blocks/` url lists all blocks while the `/block/` url has the block
hash appended to it, rendering just that block. <-- this is the one we
want.