### PR TITLE
Fix XSG foundersRewardAddressChangeInterval

### DIFF
--- a/coins/xsg.json
+++ b/coins/xsg.json
@@ -11,7 +11,7 @@
     "payFoundersReward": true,
     "percentFoundersReward": 5,
     "maxFoundersRewardBlockHeight": 2106399,
-    "foundersRewardAddressChangeInterval": 105320.95,
+    "foundersRewardAddressChangeInterval": 105320,
     "vFoundersRewardAddress": [
         "s3d27MhkBRt3ha2UuxhjXaYF4DCnttTMnL1",
         "s3Wws6Mx3GHJkAe8QkNr4jhW28WU21Fp9gL",


### PR DESCRIPTION
It seems the XSG node doesn't want a float for this value. Using an int returns a value that the XSG node accepts.

While I haven't actually proven this by finding a block, I have tested the math and it seems correct. I'm waiting to find a block now but with all the pools submitting invalid blocks, it might take a bit to confirm 100%.