### PR TITLE
Fix ZEC foundersRewardAddressChangeInterval

### DIFF
--- a/coins/zec.json
+++ b/coins/zec.json
@@ -7,7 +7,7 @@
     "payFoundersReward": true,
     "percentFoundersReward": 20,
     "maxFoundersRewardBlockHeight": 849999,
-    "foundersRewardAddressChangeInterval": 17709.3125,
+    "foundersRewardAddressChangeInterval": 17709,
     "vFoundersRewardAddress": [
         "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd",
         "t3cL9AucCajm3HXDhb5jBnJK2vapVoXsop3",


### PR DESCRIPTION
The ZEC daemon expects the foundersRewardAddressChangeInterval to be an integer when calculating the founders address to send rewards to. This change ensures pools switch to the next block at the correct height.