### PR TITLE
Add overwinter to ZEC testnet

### DIFF
--- a/coins/testnet/zec.json
+++ b/coins/testnet/zec.json
@@ -2,6 +2,7 @@
     "name": "zcash_testnet",
     "symbol": "taz",
     "algorithm": "equihash",
+    "overwinter": true,
     "requireShielding": true,
     "payFoundersReward": true,
     "percentFoundersReward": 20,


### PR DESCRIPTION
As pointed out in #33 by @osheen2241, it looks like we forgot to add overwinter to this config file.