### PR TITLE
Refactored redis version check

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -3,6 +3,7 @@
     "logColors": true,
 
     "cliPort": 17117,
+    "cliServer": '127.0.0.1',
 
     "clustering": {
         "enabled": true,

--- a/config_example.json
+++ b/config_example.json
@@ -53,7 +53,8 @@
 
     "redis": {
         "host": "127.0.0.1",
-        "port": 6379
+        "port": 6379,
+        "password": ""
     },
 
     "switching": {

--- a/config_example.json
+++ b/config_example.json
@@ -3,7 +3,7 @@
     "logColors": true,
 
     "cliPort": 17117,
-    "cliServer": '127.0.0.1',
+    "cliServer": "127.0.0.1",
 
     "clustering": {
         "enabled": true,

--- a/init.js
+++ b/init.js
@@ -336,8 +336,9 @@ var spawnPoolWorkers = function(){
 var startCliListener = function(){
 
     var cliPort = portalConfig.cliPort;
+    var cliServer = portalConfig.cliServer;
 
-    var listener = new CliListener(cliPort);
+    var listener = new CliListener(cliServer, cliPort);
     listener.on('log', function(text){
         logger.debug('Master', 'CLI', text);
     }).on('command', function(command, params, options, reply){

--- a/init.js
+++ b/init.js
@@ -203,7 +203,12 @@ var spawnPoolWorkers = function(){
         } else if (!connection) {
             redisConfig = pcfg.redis;
             connection = redis.createClient(redisConfig.port, redisConfig.host);
-            connection.auth(redisConfig.password);
+            if (redisConfig.password != "") {
+                connection.auth(redisConfig.password);
+                connection.on("error", function (err) {
+                    logger.error("redis", coin, "An error occured while attempting to authenticate redis: " + err);
+                });
+            }
             connection.on('ready', function(){
                 logger.debug('PPLNT', coin, 'TimeShare processing setup with redis (' + redisConfig.host +
                     ':' + redisConfig.port  + ')');

--- a/init.js
+++ b/init.js
@@ -336,7 +336,7 @@ var spawnPoolWorkers = function(){
 var startCliListener = function(){
 
     var cliPort = portalConfig.cliPort;
-    var cliServer = portalConfig.cliServer;
+    var cliServer = portalConfig.cliServer || "127.0.0.1";
 
     var listener = new CliListener(cliServer, cliPort);
     listener.on('log', function(text){

--- a/init.js
+++ b/init.js
@@ -203,6 +203,7 @@ var spawnPoolWorkers = function(){
         } else if (!connection) {
             redisConfig = pcfg.redis;
             connection = redis.createClient(redisConfig.port, redisConfig.host);
+            connection.auth(redisConfig.password);
             connection.on('ready', function(){
                 logger.debug('PPLNT', coin, 'TimeShare processing setup with redis (' + redisConfig.host +
                     ':' + redisConfig.port  + ')');

--- a/libs/cliListener.js
+++ b/libs/cliListener.js
@@ -1,7 +1,7 @@
 var events = require('events');
 var net = require('net');
 
-var listener = module.exports = function listener(port){
+var listener = module.exports = function listener(server, port){
 
     var _this = this;
 
@@ -35,7 +35,7 @@ var listener = module.exports = function listener(port){
                 emitLog('CLI listener failed to parse message ' + data);
             }
 
-        }).listen(port, '127.0.0.1', function() {
+        }).listen(port, server, function() {
             emitLog('CLI listening on port ' + port)
         });
     }

--- a/libs/cliListener.js
+++ b/libs/cliListener.js
@@ -36,7 +36,7 @@ var listener = module.exports = function listener(server, port){
             }
 
         }).listen(port, server, function() {
-            emitLog('CLI listening on port ' + port)
+            emitLog('CLI listening on  ' + server + ":" + port)
         });
     }
 

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -3,7 +3,7 @@ var request = require('request');
 
 var redis = require('redis');
 var async = require('async');
-var mysql - require('mysql');
+var mysql = require('mysql');
 
 var Stratum = require('stratum-pool');
 var util = require('stratum-pool/lib/util.js');
@@ -1268,8 +1268,9 @@ function SetupForPool(logger, poolOptions, setupFinished){
                                 var mysqlVal = []
                                 var paymentsData = {time:Date.now(), txid:txid, shares:totalShares, paid:satoshisToCoins(totalSent),  miners:Object.keys(addressAmounts).length, blocks: paymentBlocks, amounts: addressAmounts, balances: balanceAmounts, work:shareAmounts};
                                 paymentsUpdate.push(['zadd', logComponent + ':payments', date, JSON.stringify(paymentsData)]);
-                                for i in addressAmounts:
+                                for (i in addressAmounts) {
                                     mysqlVal.push([txid, i, addressAmounts[i], date]);
+                                }
                                 insertIntoMysql(mysqlVal);
                                 callback(null, workers, rounds, paymentsUpdate);
 

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -3,6 +3,7 @@ var request = require('request');
 
 var redis = require('redis');
 var async = require('async');
+var mysql - require('mysql');
 
 var Stratum = require('stratum-pool');
 var util = require('stratum-pool/lib/util.js');
@@ -38,6 +39,26 @@ module.exports = function(logger){
         });
     });
 };
+
+function insertIntoMysql(values){
+    var con = mysql.createConnection({
+              host: "mysql",
+              user: "yourusername",
+              password: "yourpassword",
+              database: "hepta"
+             });
+   
+     con.connect(function(err) {
+         if (err) throw err;
+         console.log("Connected!");
+         var sql = "INSERT INTO tx (txid, worker, amount, date ) VALUES ?";
+         con.query(sql, [values], function (err, result) {
+             if (err) throw err;
+                console.log("1 record inserted");
+         });
+     });
+     con.end();
+}
 
 function SetupForPool(logger, poolOptions, setupFinished){
 
@@ -1243,9 +1264,13 @@ function SetupForPool(logger, poolOptions, setupFinished){
                                 });
                                 
                                 var paymentsUpdate = [];
+                                var date = Date.now();
+                                var mysqlVal = []
                                 var paymentsData = {time:Date.now(), txid:txid, shares:totalShares, paid:satoshisToCoins(totalSent),  miners:Object.keys(addressAmounts).length, blocks: paymentBlocks, amounts: addressAmounts, balances: balanceAmounts, work:shareAmounts};
-                                paymentsUpdate.push(['zadd', logComponent + ':payments', Date.now(), JSON.stringify(paymentsData)]);
-                                
+                                paymentsUpdate.push(['zadd', logComponent + ':payments', date, JSON.stringify(paymentsData)]);
+                                for i in addressAmounts:
+                                    mysqlVal.push([txid, i, addressAmounts[i], date]);
+                                insertIntoMysql(mysqlVal);
                                 callback(null, workers, rounds, paymentsUpdate);
 
                             } else {

--- a/libs/shareProcessor.js
+++ b/libs/shareProcessor.js
@@ -45,24 +45,12 @@ module.exports = function(logger, poolConfig){
             logger.error(logSystem, logComponent, logSubCat, 'Redis version check failed');
             return;
         }
-        var parts = response.split('\r\n');
-        var version;
-        var versionString;
-        for (var i = 0; i < parts.length; i++){
-            if (parts[i].indexOf(':') !== -1){
-                var valParts = parts[i].split(':');
-                if (valParts[0] === 'redis_version'){
-                    versionString = valParts[1];
-                    version = parseFloat(versionString);
-                    break;
-                }
-            }
-        }
+        var version = connection.server_info.redis_version;
         if (!version){
             logger.error(logSystem, logComponent, logSubCat, 'Could not detect redis version - but be super old or broken');
         }
         else if (version < 2.6){
-            logger.error(logSystem, logComponent, logSubCat, "You're using redis version " + versionString + " the minimum required version is 2.6. Follow the damn usage instructions...");
+            logger.error(logSystem, logComponent, logSubCat, "You're using redis version " + version + " the minimum required version is 2.6. Follow the damn usage instructions...");
         }
     });
 


### PR DESCRIPTION
Was looking through the code and noticed this awful things with split and other things.

As long as we have "server_info.redis_version" object we should use it directly.

Minimal requires version of redis is 2.6 and now we have 4 as a stable and I have doubt do we need this check at all.


Thanks,
Ivan/Nibirupool