### PR TITLE
Update Zero founders addresses

### DIFF
--- a/coins/testnet/zer.json
+++ b/coins/testnet/zer.json
@@ -8,6 +8,22 @@
             "personalization": "ZERO_PoW"
     },
     "requireShielding": true,
+    "payFoundersReward": true,
+    "percentFoundersReward": 7.5,
+    "maxFoundersRewardBlockHeight": 29999,
+    "foundersRewardAddressChangeInterval": 3000,
+    "vFoundersRewardAddress": [
+          "t2BEnZwurNtPyhyWdZ82zTdS93rKyoUpgMJ",
+          "t2AwNRubry4rQrEvHwAdpYve4Gz5cSmjGXA",
+          "t2FM2EZqQZANA18rbhBGLWbxKcpGk9soAvS",
+          "t2TBZfnXRCmFPc3nSrQcNtnR6AGWNzF9hzz",
+          "t2QMyS1C3jXJ5hcR7zJTPSbWFvMWQEyjVTE",
+          "t2SxA3E34aZJDDxnUxC2gZXBVrXWuoH5v7W",
+          "t2FhR8STLvuKTUPgM586T1LMUG4JAHV2XSt",
+          "t2NScRwr3FHPN8fNSgMKn8ngZG2kgfC8JNt",
+          "t2LYZj3LiCDaCGUXQNXH1ZFPmHiC46wB9se",
+          "t28azskSALVTtgbW63CqDwzXgtWQ56GVVXa"
+    ],
     "txfee": 0.0001,
     "peerMagic": "5a45524f",
     "explorer": {

--- a/coins/zer.json
+++ b/coins/zer.json
@@ -8,7 +8,7 @@
             "personalization": "ZERO_PoW"
     },
     "requireShielding": true,
-    "percentTreasuryReward": 7.5
+    "percentTreasuryReward": 7.5,
     "treasuryRewardStartBlockHeight": 410000,
     "treasuryRewardAddressChangeInterval": 0,
     "vTreasuryRewardAddress": [
@@ -22,4 +22,3 @@
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://zeroexplorer.forgetop.com/tx/). The pool will automatically add the transaction id or block id at the end."
     }
 }
-

--- a/coins/zer.json
+++ b/coins/zer.json
@@ -8,11 +8,21 @@
             "personalization": "ZERO_PoW"
     },
     "requireShielding": true,
-    "percentTreasuryReward": 7.5,
-    "treasuryRewardStartBlockHeight": 410000,
-    "treasuryRewardAddressChangeInterval": 0,
-    "vTreasuryRewardAddress": [
-        "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
+    "payFoundersReward": true,
+    "percentFoundersReward": 7.5,
+    "maxFoundersRewardBlockHeight": 7999999,
+    "foundersRewardAddressChangeInterval": 800000,
+    "vFoundersRewardAddress": [
+          "t3hmg6WApjqVFw9oPWTDy4JLEqXcUWthg5v", 
+          "t3hrh5M7eaGA5zXCitPXz2pbe146GkVPWHs",
+          "t3aWmHqBGS7watoKQLa7uykeTaYHoYqM361",
+          "t3hsi89hPsZzmnbs3pny6cfAxMxV5TJLErj", 
+          "t3TdGxPVUdMXd6qDrDCEuJETLadZ9Ki3s9r",
+          "t3cb5ZjKmbGbqDaYk97Auam9kXXikGQBmyY",
+          "t3V1YovGUPW9WSBoAHS48FDdUfUTo6LDpZR",
+          "t3KB9n28MVg31oo856t1tQGfJuYq8usTvSi", 
+          "t3dqSV4YGj5V3WjQhqFGrKTMUf9Tgc6xnJM",
+          "t3aJkYT1i6tyytq8J6khPaDNtgZsBSXgfBf", 
     ],
     "txfee": 0.0001,
     "peerMagic": "5a45524f",

--- a/coins/zer.json
+++ b/coins/zer.json
@@ -10,7 +10,6 @@
     "requireShielding": true,
     "payFoundersReward": true,
     "percentFoundersReward": 7.5,
-    "maxFoundersRewardBlockHeight": 410000,
     "vFoundersRewardAddress": [
         "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
     ],

--- a/coins/zer.json
+++ b/coins/zer.json
@@ -8,9 +8,10 @@
             "personalization": "ZERO_PoW"
     },
     "requireShielding": true,
-    "payFoundersReward": true,
-    "percentFoundersReward": 7.5,
-    "vFoundersRewardAddress": [
+    "percentTreasuryReward": 7.5
+    "treasuryRewardStartBlockHeight": 410000,
+    "treasuryRewardAddressChangeInterval": 0,
+    "vTreasuryRewardAddress": [
         "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
     ],
     "txfee": 0.0001,

--- a/coins/zer.json
+++ b/coins/zer.json
@@ -22,7 +22,7 @@
           "t3V1YovGUPW9WSBoAHS48FDdUfUTo6LDpZR",
           "t3KB9n28MVg31oo856t1tQGfJuYq8usTvSi", 
           "t3dqSV4YGj5V3WjQhqFGrKTMUf9Tgc6xnJM",
-          "t3aJkYT1i6tyytq8J6khPaDNtgZsBSXgfBf", 
+          "t3aJkYT1i6tyytq8J6khPaDNtgZsBSXgfBf"
     ],
     "txfee": 0.0001,
     "peerMagic": "5a45524f",

--- a/coins/zer.json
+++ b/coins/zer.json
@@ -8,6 +8,12 @@
             "personalization": "ZERO_PoW"
     },
     "requireShielding": true,
+    "payFoundersReward": true,
+    "percentFoundersReward": 7.5,
+    "maxFoundersRewardBlockHeight": 410000,
+    "vFoundersRewardAddress": [
+        "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
+    ],
     "txfee": 0.0001,
     "peerMagic": "5a45524f",
     "explorer": {


### PR DESCRIPTION
Updated to add ZERO's treasury  model starting at block 410000.