### PR TITLE
Added Bithereum Testnet and Mainnet pool configuration

### DIFF
--- a/coins/bth.json
+++ b/coins/bth.json
@@ -1,0 +1,17 @@
+{
+    "name": "bithereum",
+    "symbol": "bth",
+    "algorithm": "equihash",
+    "parameters": {
+        "N": 144,
+        "K": 5,
+        "personalization": "BethdPoW"
+    },
+    "peerMagic": "e1476d44",
+
+    "explorer": {
+        "txURL": "http://explorer.bithereum.network/tx/",
+        "blockURL": "http://explorer.bithereum.network/block/",
+        "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (http://explorer.bithereum.network/tx/). The pool will automatically add the transaction id or block id at the end."
+    }
+}

--- a/coins/bth.json
+++ b/coins/bth.json
@@ -7,7 +7,7 @@
         "K": 5,
         "personalization": "BethdPoW"
     },
-    "peerMagic": "e1476d44",
+    "peerMagic": "e3486a45",
 
     "explorer": {
         "txURL": "http://explorer.bithereum.network/tx/",

--- a/coins/testnet/bth.json
+++ b/coins/testnet/bth.json
@@ -1,0 +1,17 @@
+{
+    "name": "bithereum_testnet",
+    "symbol": "tbth",
+    "algorithm": "equihash",
+    "parameters": {
+        "N": 144,
+        "K": 5,
+        "personalization": "BethdPoW"
+    },
+    "peerMagic": "e2486e45",
+
+    "explorer": {
+        "txURL": "http://testnet-explorer.bithereum.network/tx/",
+        "blockURL": "http://testnet-explorer.bithereum.network/block/",
+        "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (http://testnet-explorer.bithereum.network/tx/). The pool will automatically add the transaction id or block id at the end."
+    }
+}


### PR DESCRIPTION
Added Bithereum (BTH) as an available coin. The mainnet explorer links will be fully functional a little after December 7th, when the snapshot is made. Testnet links are otherwise live.