### PR TITLE
Horizen 20% Treasury update

### DIFF
--- a/coins/testnet/zen.json
+++ b/coins/testnet/zen.json
@@ -50,6 +50,9 @@
         "zrFr5HVm7woVq3oFzkMEdJdbfBchfPAPDsP",
         "zrFr5HVm7woVq3oFzkMEdJdbfBchfPAPDsP"
     ],
+    "percentTreasury20pctUpdateReward": 20.0,
+    "treasuryReward20pctUpdateStartBlockHeight":369900,
+    "peerMagic": "bff2cde6",
     "txfee": 0.0004,
 
     "explorer": {

--- a/coins/zen.json
+++ b/coins/zen.json
@@ -89,6 +89,8 @@
         "zsnL6pKdzvZ1BPVzALUoqw2KsY966XFs5CE",
         "zsnL6pKdzvZ1BPVzALUoqw2KsY966XFs5CE"
     ],
+    "percentTreasury20pctUpdateReward": 20.0,
+    "treasuryReward20pctUpdateStartBlockHeight": 455555,
     "peerMagic": "63617368",
     "txfee": 0.0004,
 


### PR DESCRIPTION
This adds support for the upcoming Horizen hardfork (testnet block 369900, mainnet block 455555) changing the community fund block reward to 20% and adding groth sprout shielded transaction support.

Depends on https://github.com/s-nomp/node-stratum-pool/pull/32