### PR TITLE
payZelNodes to zel.json config

### DIFF
--- a/coins/zel.json
+++ b/coins/zel.json
@@ -11,6 +11,7 @@
     "txfee": 0.0001,
     "peerMagic": "24e92764",
     "sapling": true,
+    "payZelNodes": 1550952000,
     "explorer": {
         "txURL": "https://explorer.zel.cash/tx/",
         "blockURL": "https://explorer.zel.cash/block/",


### PR DESCRIPTION
ZelNodes payouts will be enforced by spork on timestamp 1550952000 which is GMT: Saturday, 23 February 2019 20:00:00
Pool operators should update their zelcash daemon, node-stratum-pool module and their zel.json configuration with this timestamp for smooth transition.