### PR TITLE
Expose last share timestamp for each miner / worker in API

### DIFF
--- a/libs/stats.js
+++ b/libs/stats.js
@@ -501,14 +501,19 @@ module.exports = function(logger, portalConfig, poolConfigs){
                     var miner = parts[1].split('.')[0];
                     var worker = parts[1];
                     var diff = Math.round(parts[0] * 8192);
+                    var lastShare = parseInt(parts[2]);
                     if (workerShares > 0) {
                         coinStats.shares += workerShares;
                         // build worker stats
                         if (worker in coinStats.workers) {
                             coinStats.workers[worker].shares += workerShares;
                             coinStats.workers[worker].diff = diff;
+                            if (lastShare > coinStats.workers[worker].lastShare) {
+                                coinStats.workers[worker].lastShare = lastShare;
+                            }
                         } else {
                             coinStats.workers[worker] = {
+                                lastShare: 0,
                                 name: worker,
                                 diff: diff,
                                 shares: workerShares,
@@ -526,8 +531,12 @@ module.exports = function(logger, portalConfig, poolConfigs){
                         // build miner stats
                         if (miner in coinStats.miners) {
                             coinStats.miners[miner].shares += workerShares;
+                            if (lastShare > coinStats.miners[miner].lastShare) {
+                                coinStats.miners[miner].lastShare = lastShare;
+                            }
                         } else {
                             coinStats.miners[miner] = {
+                                lastShare: 0,
                                 name: miner,
                                 shares: workerShares,
                                 invalidshares: 0,
@@ -547,6 +556,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
                             coinStats.workers[worker].diff = diff;
                         } else {
                             coinStats.workers[worker] = {
+                                lastShare: 0,
                                 name: worker,
                                 diff: diff,
                                 shares: 0,
@@ -566,6 +576,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
                             coinStats.miners[miner].invalidshares -= workerShares; // workerShares is negative number!
                         } else {
                             coinStats.miners[miner] = {
+                                lastShare: 0,
                                 name: miner,
                                 shares: 0,
                                 invalidshares: -workerShares,


### PR DESCRIPTION
It's useful in a UI to have the timestamp of the last share for every miners' workers.
The current s-nomp API does not expose this information, but it is stored in redis.
Let's expose it in the API.

Until now, I had to fudge the "last share" data for my pool, each worker seemed to be in sync:
![image](https://user-images.githubusercontent.com/1062488/61585904-ccda8480-ab35-11e9-9de2-4bcef0cb0b71.png)

After applying this patch, I have better detail in the API:
```json
     {
        "RRNHfxjNaJ9zC7FYcYCVPuXLPpk9Vs3hFu.voskcoin": {
          "lastShare": 1563672761500,
          "name": "RRNHfxjNaJ9zC7FYcYCVPuXLPpk9Vs3hFu.voskcoin",
          "diff": 2663892268,
          "shares": 8129554.041592247,
          "invalidshares": 325182.16166369,
          "currRoundShares": 8249087416.608933,
          "currRoundTime": 233703.447,
          "hashrate": 116387229132344.4,
          "hashrateString": "232.77 MH/s",
          "luckDays": "1.452",
          "luckHours": "34.859",
          "paid": 0,
          "balance": 0
        },
        "RRNHfxjNaJ9zC7FYcYCVPuXLPpk9Vs3hFu.voskcoin2": {
          "lastShare": 1563672772522,
          "name": "RRNHfxjNaJ9zC7FYcYCVPuXLPpk9Vs3hFu.voskcoin2",
          "diff": 281319519,
          "shares": 824178.2783126401,
          "invalidshares": 0,
          "currRoundShares": 630672034.5685258,
          "currRoundTime": 233703.447,
          "hashrate": 11799395838087.918,
          "hashrateString": "23.60 MH/s",
          "luckDays": "14.327",
          "luckHours": "343.846",
          "paid": 0,
          "balance": 0
        }
      }
```

Pool UI now shows individual share times from each worker:
![image](https://user-images.githubusercontent.com/1062488/61585932-6d30a900-ab36-11e9-9823-f9ba94635852.png)

screenshots taken from the VerusCoin mining pool at [verus.wattpool.net](https://verus.wattpool.net)