### PR TITLE
website/pages/api.html: fix copy/paste error: stats -> blocks

### DIFF
--- a/website/pages/api.html
+++ b/website/pages/api.html
@@ -3,7 +3,7 @@
 
 <ul>
 <li><a href="/api/stats">/stats</a> global pool stats</li>
-<li><a href="/api/blocks">/stats</a> global block stats</li>
+<li><a href="/api/blocks">/blocks</a> global block stats</li>
 <li><a href="/api/pool_stats">/pool_stats</a> - historical stats</li>
 <li><a href="/api/payments">/payments</a> - payment history</li>
 <li><a href="/api/worker_stats?taddr">/worker_stats?taddr</a> - historical time per pool json </li>


### PR DESCRIPTION
The link for `api/blocks` should read as "blocks" rather than "stats":

![image](https://user-images.githubusercontent.com/1062488/62008095-4caeb300-b123-11e9-9d76-f085507ecd9d.png)
