### PR TITLE
Fix regression introduced by #141

### DIFF
--- a/libs/website.js
+++ b/libs/website.js
@@ -134,7 +134,7 @@ module.exports = function(logger){
     var buildKeyScriptPage = function(){
         async.waterfall([
             function(callback){
-                var client = CreateRedisClient(portalConfig);
+                var client = CreateRedisClient(portalConfig.redis);
                 if (portalConfig.redis.password) {
                     client.auth(portalConfig.redis.password);
                 }


### PR DESCRIPTION
This fixes a small bug introduced with unix domain socket support in website.js.
```
2019-09-26 23:03:09 [Website]       [Server] Website started on 0.0.0.0:8080
events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED 127.0.0.1:6379
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1106:14)
Emitted 'error' event at:
    at RedisClient.on_error (/home/node/s-nomp/node_modules/redis/index.js:406:14)
    at Socket.<anonymous> (/home/node/s-nomp/node_modules/redis/index.js:279:14)
    at Socket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
2019-09-26 23:03:09 [Master]        [Website] Website process died, spawning replacement...
```