### PR TITLE
On LitecoinZ, requireShielding is now optional

### DIFF
--- a/coins/ltz.json
+++ b/coins/ltz.json
@@ -8,7 +8,7 @@
         "K": 5,
         "personalization": "ZcashPoW"
     },
-    "requireShielding": true,
+    "requireShielding": false,
     "txfee": 0.0001,
     "peerMagic": "d8cfcd93",
     "explorer": {

--- a/pool_configs/examples/ltz.json
+++ b/pool_configs/examples/ltz.json
@@ -6,10 +6,10 @@
     "_comment_address": "a transparent address to send coinbase rewards to and to transfer to zAddress.",
 
     "zAddress": "",
-    "_comment_zAddress": "a private address used to send coins to tAddress.",
+    "_comment_zAddress": "a private address used to send coins to tAddress. Staring from v3.0.0 this is optional.",
 
     "tAddress": "",
-    "_comment_tAddress": "transparent address used to send payments, make this a different address, otherwise payments will not send",
+    "_comment_tAddress": "transparent address used to send payments, make this a different address, otherwise payments will not send. Staring from v3.0.0 this is optional.",
 
     "invalidAddress": "",
     "_comment_invalidAddress": "Invalid addresses will be converted to the above",

--- a/pool_configs/examples/ltz_testnet.json
+++ b/pool_configs/examples/ltz_testnet.json
@@ -6,10 +6,10 @@
     "_comment_address": "a transparent address to send coinbase rewards to and to transfer to zAddress.",
 
     "zAddress": "",
-    "_comment_zAddress": "a private address used to send coins to tAddress.",
+    "_comment_zAddress": "a private address used to send coins to tAddress. Staring from v3.0.0 this is optional.",
 
     "tAddress": "",
-    "_comment_tAddress": "transparent address used to send payments, make this a different address, otherwise payments will not send",
+    "_comment_tAddress": "transparent address used to send payments, make this a different address, otherwise payments will not send. Staring from v3.0.0 this is optional.",
 
     "invalidAddress": "",
     "_comment_invalidAddress": "Invalid addresses will be converted to the above",


### PR DESCRIPTION
Staring from v3.0.0 shielding coinbase for payments is now optional. Payments could be done directly using transparent addresses. This will relax and use less compute resource on pools.