### PR TITLE
z_sendmany to z_shieldcoinbase

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -242,21 +242,21 @@ function SetupForPool(logger, poolOptions, setupFinished){
         if (callback === true)
             return;
         if (tBalance === NaN) {
-            logger.error(logSystem, logComponent, 'tBalance === NaN for sendTToZ');
+            logger.error(logSystem, logComponent, 'tBalance === NaN for shieldcoinbase');
             return;
         }
         if ((tBalance - 10000) <= 0)
             return;
 
-        // do not allow more than a single z_sendmany operation at a time
+        // do not allow more than a single z_shieldcoinbase operation at a time
         if (opidCount > 0) {
-            logger.warning(logSystem, logComponent, 'sendTToZ is waiting, too many z_sendmany operations already in progress.');
+            logger.warning(logSystem, logComponent, 'shieldcoinbase is waiting, too many operations already in progress.');
             return;
         }
 
         var amount = satoshisToCoins(tBalance - 10000);
-        var params = [poolOptions.address, [{'address': poolOptions.zAddress, 'amount': amount}]];
-        daemon.cmd('z_sendmany', params,
+        var params = [poolOptions.address, poolOptions.zAddress];
+        daemon.cmd('z_shieldcoinbase', params,
             function (result) {
                 //Check if payments failed because wallet doesn't have enough coins to pay for tx fees
                 if (!result || result.error || result[0].error || !result[0].response) {
@@ -265,10 +265,10 @@ function SetupForPool(logger, poolOptions, setupFinished){
                     callback(true);
                 }
                 else {
-                    var opid = (result.response || result[0].response);                    
+                    var opid = (result.response || result[0].response);
                     opidCount++;
                     opids.push(opid);
-                    logger.special(logSystem, logComponent, 'Shield balance ' + amount + ' ' + opid);
+                    logger.special(logSystem, logComponent, 'Shielding balance ' + amount);
                     callback = function (){};
                     callback(null);
                 }


### PR DESCRIPTION
I've implemented this on my own pool 2 years ago and haven't spotted any issues. It simply modifies the payment processor to use [z_shieldcoinbase](https://zcash-rpc.github.io/z_shieldcoinbase.html) instead of [z_sendmany](https://zcash-rpc.github.io/z_sendmany.html) for moving coins from coinbase to the pools Z address. 