### PR TITLE
Defined confirmations to mature blocks

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -792,6 +792,15 @@ function SetupForPool(logger, poolOptions, setupFinished){
                         // get transaction category for round
                         round.category = generationTx.category
 
+                        //Consider block mature if block confirmations is >= to confirmations defined in poolOptions
+                        if (round.confirmations >= poolOptions.coin.poolOptions.confirmations || 100) {
+                            round.category = 'generate';
+                        }
+
+                        if (poolOptions.coin.poolOptions.confirmations =< 10) {
+                            logger.warning(logSystem, logComponent, logComponent + ' block confirmations > 10 recommended!');
+                        }
+
                         // get reward for newly generated blocks
                         if (round.category === 'generate' || round.category === 'immature') {
                             round.reward = coinsRound(parseFloat(generationTx.amount || generationTx.value))

--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -153,7 +153,7 @@
                     {{ } }}
                     {{if (it.stats.pools[pool].pending.confirms) { }}
                         {{if (it.stats.pools[pool].pending.confirms[block[0]]) { }}
-                        <span style="float:right; color: red;"><small>{{=it.stats.pools[pool].pending.confirms[block[0]]}} of 100</small></span>
+                        <span style="float:right; color: red;"><small>{{=it.stats.pools[pool].pending.confirms[block[0]]}} of {{=it.poolsConfigs[pool].coin.poolOptions.confirmations}}</small></span>
                         {{ } else { }}
                         <span style="float:right; color: red;"><small>*PENDING*</small></span>
                         {{ } }}


### PR DESCRIPTION
Some coins have higher confirmation requirements than necessary (such as zerc at 720). This modification sets the default to 100 as usual, but allows customization in the coins file to allow a lower/or higher limit.

It requires you to add the following in your coins file

```
    "poolOptions": {
        "confirmations": 100
    }
```

Other options will be added later which I can update the coin files to add this by default. For now, I doubt anyone is searching for it.