### PR TITLE
Allow defined confirmations for block mature

### DIFF
--- a/coins/zerc.json
+++ b/coins/zerc.json
@@ -15,5 +15,8 @@
         "txURL": "http://explorer.zeroclassic.org/tx/",
         "blockURL": "http://explorer.zeroclassic.org/block/",
         "_comment_explorer": "This is the coin's explorer full base url for transaction and blocks i.e. (https://explorer.coin.com/tx/). The pool will automatically add the transaction id or block id at the end."
+    },
+    "poolOptions": {
+        "confirmations": 720
     }
 }

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -795,6 +795,19 @@ function SetupForPool(logger, poolOptions, setupFinished){
                         // get transaction category for round
                         round.category = generationTx.category
 
+                        //Pay before daemon considers mature
+                        if (typeof poolOptions.coin.poolOptions.confirmations === 'undefined') {
+                            poolOptions.coin.poolOptions.confirmations = 100;
+                        }
+
+                        if (round.confirmations >= poolOptions.coin.poolOptions.confirmations) {
+                            round.category = 'generate';
+                        } else if (round.confirmations <= poolOptions.coin.poolOptions.confirmations) {
+                            round.category = 'immature';
+                        } else {
+                            round.category;
+                        }
+
                         // get reward for newly generated blocks
                         if (round.category === 'generate' || round.category === 'immature') {
                             round.reward = coinsRound(parseFloat(generationTx.amount || generationTx.value))

--- a/pool_configs/examples/zec.testnet.json
+++ b/pool_configs/examples/zec.testnet.json
@@ -31,7 +31,7 @@
         "maxBlocksPerPayment": 3,
         "daemon": {
             "host": "127.0.0.1",
-            "port": 18233,
+            "port": 18232,
             "user": "rpcuser",
             "password": "rpcpassword"
         }
@@ -64,7 +64,7 @@
     "daemons": [
         {
             "host": "127.0.0.1",
-            "port": 18233,
+            "port": 18232,
             "user": "rpcuser",
             "password": "rpcpassword"
         }

--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -152,8 +152,9 @@
                     <span style="padding-left: 18px;"><small>{{=readableDate(block[4])}}</small></span>
                     {{ } }}
                     {{if (it.stats.pools[pool].pending.confirms) { }}
+                        {{if (typeof it.poolsConfigs[pool].coin.poolOptions.confirmations === 'undefined') { it.poolsConfigs[pool].coin.poolOptions.confirmations = 100; }}}
                         {{if (it.stats.pools[pool].pending.confirms[block[0]]) { }}
-                        <span style="float:right; color: red;"><small>{{=it.stats.pools[pool].pending.confirms[block[0]]}} of 100</small></span>
+                        <span style="float:right; color: red;"><small>{{=it.stats.pools[pool].pending.confirms[block[0]]}} of {{=it.poolsConfigs[pool].coin.poolOptions.confirmations}}</small></span>
                         {{ } else { }}
                         <span style="float:right; color: red;"><small>*PENDING*</small></span>
                         {{ } }}


### PR DESCRIPTION
This feature will allow you  to set a custom number for block maturity. It is simply visual, and requires mature funds to be able to pay anything. This is useful for chains with high maturity numbers such as ZeroClassic at 720 (24 hours). 

The following is required in your coins file

```
    "poolOptions": {
        "confirmations": 150
    }
````

The default is 100 if no confirmations are defined in the coins config file.