### PR TITLE
Fix Ycash config file

### DIFF
--- a/coins/yec.json
+++ b/coins/yec.json
@@ -10,7 +10,7 @@
     "requireShielding": true,
     "payFoundersReward": true,
     "percentFoundersReward": 5,
-    "maxFoundersRewardBlockHeight": 1849999,
+    "maxFoundersRewardBlockHeight": 9E15,
     "foundersRewardAddressChangeInterval": 17917,
     "vYcashFoundersRewardAddress": [
         "s1hfWJ4ej1H3s8XCUb7YnrU68K64AsGVUHE",


### PR DESCRIPTION
This fixes the maxFoundersRewardBlockHeight value in the Ycash config file. The current block height is now greater than the current value of maxFoundersRewardBlockHeight, but Ycash does not have a maxFoundersRewardBlockHeight (a result of reducing the original Zcash Founder's Reward from 20% to 5%).

Thank you to the CRYPTO 2MARS mining pool team for testing this pull request in production.